### PR TITLE
Change dependency version of snomed-template-parser from 1.2.0 to 1.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 		<dependency>
 			<groupId>org.snomed.languages</groupId>
 			<artifactId>snomed-template-parser</artifactId>
-			<version>1.2.0</version>
+			<version>1.2.2</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.slf4j</groupId>


### PR DESCRIPTION
Version 1.2.0 of snomed-template-parser isn't on Nexus; I've bumped the dependency version to one that is.