### PR TITLE
FRI-225 - Update ihtsdo-spring-sso version and security configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
 		<dependency>
 			<groupId>org.ihtsdo.otf</groupId>
 			<artifactId>ihtsdo-spring-sso</artifactId>
-			<version>2.1.0</version>
+			<version>3.1.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.ihtsdo.otf.common</groupId>
@@ -156,19 +156,19 @@
 	
 	<build>
 		<plugins>
-        <plugin>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <configuration>
-            <source>11</source>
-            <target>11</target>
-            <release>11</release>
-            <forceJavacCompilerUse>true</forceJavacCompilerUse>
-            <compilerArgs>
-                <arg>-Werror</arg>
-                <arg>-verbose</arg>
-            </compilerArgs>
-          </configuration>
-        </plugin>
+			<plugin>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<source>11</source>
+					<target>11</target>
+					<release>11</release>
+					<forceJavacCompilerUse>true</forceJavacCompilerUse>
+					<compilerArgs>
+						<arg>-Werror</arg>
+						<arg>-verbose</arg>
+					</compilerArgs>
+				</configuration>
+			</plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>

--- a/src/main/java/org/ihtsdo/otf/transformationandtemplate/configuration/Config.java
+++ b/src/main/java/org/ihtsdo/otf/transformationandtemplate/configuration/Config.java
@@ -86,15 +86,6 @@ public class Config extends WebSecurityConfigurerAdapter {
 				"/(.*)/recipes/.*"
 		));
 	}
-	
-	@SuppressWarnings("rawtypes")
-	@Bean
-	public FilterRegistrationBean getSingleSignOnFilter() {
-		FilterRegistrationBean filterRegistrationBean = new FilterRegistrationBean<>(
-				new RequestHeaderAuthenticationDecorator());
-		filterRegistrationBean.setOrder(1);
-		return filterRegistrationBean;
-	}
 
 	// Swagger Config
 	@Bean
@@ -124,7 +115,6 @@ public class Config extends WebSecurityConfigurerAdapter {
 	public void configure(WebSecurity web) {
 		web.httpFirewall(allowUrlEncodedSlashHttpFirewall());
 	}
-	
 	
 	@Bean
 	public HttpFirewall allowUrlEncodedSlashHttpFirewall() {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,7 @@
 server.servlet.context-path=/template-service
 server.port=8086
+
+# Basic authentication
 spring.security.user.name=user
 spring.security.user.password=password
 


### PR DESCRIPTION
Updated ihtsdo-spring-sso version

Removed duplicate bean registration as we already register `RequestHeaderAuthenticationDecorator` within Spring Security filter chain in `configure()` method to be called after `BasicAuthenticationFilter`:

`http.addFilterAfter(new RequestHeaderAuthenticationDecorator(), BasicAuthenticationFilter.class);`

@CoderMChu this is low priority, please review when you have time. Thank you!